### PR TITLE
Fixing Saving Bug for Tour History and Achievements

### DIFF
--- a/TourAR/Assets/Editor/sceneLoaderTest.cs
+++ b/TourAR/Assets/Editor/sceneLoaderTest.cs
@@ -53,8 +53,8 @@ public class sceneLoaderTest : MonoBehaviour
     public void ClearTourHistory()
     {
         var manageTH = new manageTourHistory();
-        manageTH.addStopToHistory("rutledge", "today");
-        manageTH.addStopToHistory("rutledge2", "today");
+        manageTH.addStopToHistory("rutledge");
+        manageTH.addStopToHistory("rutledge2");
         manageTH.clearTourHistory(); //ensure that local data doesn't mess up the test
         var THobj = manageTH.getTourHistory();
         Assert.AreEqual(0, THobj.Count);
@@ -65,7 +65,7 @@ public class sceneLoaderTest : MonoBehaviour
     {
         var manageTH = new manageTourHistory();
         manageTH.clearTourHistory(); //ensure that local data doesn't mess up the test
-        manageTH.addStopToHistory("rutledge", "today");
+        manageTH.addStopToHistory("rutledge");
         var THobj = manageTH.getTourHistory();
         Assert.AreEqual(1, THobj.Count);
     }

--- a/TourAR/Assets/Editor/sceneLoaderTest.cs
+++ b/TourAR/Assets/Editor/sceneLoaderTest.cs
@@ -112,7 +112,7 @@ public class sceneLoaderTest : MonoBehaviour
     {
         //Arrange
         var manager = new GameObject("loadTourStops").AddComponent<loadTourStops>();
-        manager.prepForTests();
+        manager.prepForUse();
         var title = manager.getTitleForTourStop("rutledgeCollege");
         //Assert
         Assert.AreEqual(title, "Rutledge College");
@@ -123,7 +123,7 @@ public class sceneLoaderTest : MonoBehaviour
     {
         //Arrange
         var manager = new GameObject("loadTourStops").AddComponent<loadTourStops>();
-        manager.prepForTests();
+        manager.prepForUse();
         var title = manager.getTitleForTourStop("invalidTourStop");
         //Assert
         Assert.AreEqual(title, "n/a no match found for this building ID");
@@ -134,7 +134,7 @@ public class sceneLoaderTest : MonoBehaviour
     {
         //Arrange
         var manager = new GameObject("loadTourStops").AddComponent<loadTourStops>();
-        manager.prepForTests();
+        manager.prepForUse();
         var meta = manager.getMetadataForTourStop("rutledgeCollege");
         String[] separator = {"\n\n"};
         var pieces = meta.Split(separator, 3, StringSplitOptions.RemoveEmptyEntries);
@@ -149,7 +149,7 @@ public class sceneLoaderTest : MonoBehaviour
     {
         //Arrange
         var manager = new GameObject("loadTourStops").AddComponent<loadTourStops>();
-        manager.prepForTests();
+        manager.prepForUse();
         var desc = manager.getStopDescription("Thomas Cooper Library");
         //Assert
         Assert.AreEqual(desc, "Thomas Cooper Library, constructed in 1976, is the home of the University Libraries. Here, students can rent books, reserve study space, and browse special collections of maps, art, music, manuscripts and more.");
@@ -160,7 +160,7 @@ public class sceneLoaderTest : MonoBehaviour
     {
         //Arrange
         var manager = new GameObject("loadTourStops").AddComponent<loadTourStops>();
-        manager.prepForTests();
+        manager.prepForUse();
         var desc = manager.getStopDescription("invalidTourStop");
         //Assert
         Assert.AreEqual(desc, "n/a couldn't find a match");

--- a/TourAR/Assets/Resources/JSON/achievements.json
+++ b/TourAR/Assets/Resources/JSON/achievements.json
@@ -1,1 +1,32 @@
-[{"name":"1st Stop!","condition":1,"isCompleted":false,"description":"You've visited your first tour stop!"},{"name":"Tour Stop Rookie!","condition":3,"isCompleted":false,"description":"You've visited at least 3 tour stops!"},{"name":"Tour Stop Frequenter!","condition":5,"isCompleted":false,"description":"You've visited at least 5 tour stops!"},{"name":"Tour Stop Expert!","condition":10,"isCompleted":false,"description":"You've visited at least 10 tour stops!"},{"name":"Tour Stop Master!","condition":15,"isCompleted":false,"description":"You've visited at least 15 tour stops!"}]
+[
+  {
+    "name": "1st Stop!",
+    "condition": 1,
+    "isCompleted": false,
+    "description": "You've visited your first tour stop!"
+  },
+  {
+    "name": "Tour Stop Rookie!",
+    "condition": 3,
+    "isCompleted": false,
+    "description": "You've visited at least 3 tour stops!"
+  },
+  {
+    "name": "Tour Stop Frequenter!",
+    "condition": 5,
+    "isCompleted": false,
+    "description": "You've visited at least 5 tour stops!"
+  },
+  {
+    "name": "Tour Stop Expert!",
+    "condition": 10,
+    "isCompleted": false,
+    "description": "You've visited at least 10 tour stops!"
+  },
+  {
+    "name": "Tour Stop Master!",
+    "condition": 15,
+    "isCompleted": false,
+    "description": "You've visited at least 15 tour stops!"
+  }
+]

--- a/TourAR/Assets/Resources/JSON/tourHistory.json
+++ b/TourAR/Assets/Resources/JSON/tourHistory.json
@@ -1,6 +1,5 @@
 [
     {
-        "stopID": "horseshoe",
-        "completionDate": "2/2/2020"
+        "stopID": "horseshoe"
     }
 ]

--- a/TourAR/Assets/Resources/JSON/tourHistory.json
+++ b/TourAR/Assets/Resources/JSON/tourHistory.json
@@ -1,5 +1,2 @@
 [
-    {
-        "stopID": "horseshoe"
-    }
 ]

--- a/TourAR/Assets/Scripts/AR/loadTourStops.cs
+++ b/TourAR/Assets/Scripts/AR/loadTourStops.cs
@@ -93,6 +93,18 @@ public class loadTourStops : MonoBehaviour
         return tourStops;
     }
 
+    public static string getStopName(string bID)
+    {
+        string retVal = "n/a";
+        for (int i = 0; i < tourStops.Count; i++)
+        {
+            if (tourStops[i].buildingID.Equals(bID))
+            {
+                return tourStops[i].name;
+            }
+        }
+        return retVal;
+    }
     public string getTitleForTourStop(string bID)
     {
         //title
@@ -145,7 +157,7 @@ public class loadTourStops : MonoBehaviour
       }
     }
 
-    public string[] getAllDataForTourStop(string bID)
+    public static string[] getAllDataForTourStop(string bID)
     {
         string[] retVal = new string[2];
         for (int i = 0; i < tourStops.Count; i++)

--- a/TourAR/Assets/Scripts/AR/loadTourStops.cs
+++ b/TourAR/Assets/Scripts/AR/loadTourStops.cs
@@ -83,7 +83,7 @@ public class loadTourStops : MonoBehaviour
         //Debug.Log("finished convert");
     }
 
-    public void prepForTests()
+    public void prepForUse()
     {
         loadTheTourStops();
     }

--- a/TourAR/Assets/Scripts/AR/loadTourStops.cs
+++ b/TourAR/Assets/Scripts/AR/loadTourStops.cs
@@ -93,18 +93,6 @@ public class loadTourStops : MonoBehaviour
         return tourStops;
     }
 
-    public static string getStopName(string bID)
-    {
-        string retVal = "n/a";
-        for (int i = 0; i < tourStops.Count; i++)
-        {
-            if (tourStops[i].buildingID.Equals(bID))
-            {
-                return tourStops[i].name;
-            }
-        }
-        return retVal;
-    }
     public string getTitleForTourStop(string bID)
     {
         //title

--- a/TourAR/Assets/Scripts/Achievements/ButtonListButton.cs
+++ b/TourAR/Assets/Scripts/Achievements/ButtonListButton.cs
@@ -8,7 +8,7 @@ public class ButtonListButton : MonoBehaviour
 
     [SerializeField]
     private Text myText;
-    
+
     [SerializeField]
     private Image myIcon;
 
@@ -25,7 +25,7 @@ public class ButtonListButton : MonoBehaviour
     public void SetIcon(Sprite mySprite) {
         myIcon.sprite = mySprite;
     }
- 
+
     public void OnClick() {
         buttonControl.ButtonClicked(myTextString);
     }

--- a/TourAR/Assets/Scripts/Achievements/ButtonListControl.cs
+++ b/TourAR/Assets/Scripts/Achievements/ButtonListControl.cs
@@ -17,7 +17,7 @@ public class ButtonListControl : MonoBehaviour
     void Start()
     {
         buttons = new List<GameObject>();
-
+        achievementScore.loadCountBIDS();
         if (buttons.Count > 0) {
             foreach (GameObject button in buttons) {
                 Destroy(button.gameObject);

--- a/TourAR/Assets/Scripts/Achievements/achievementScore.cs
+++ b/TourAR/Assets/Scripts/Achievements/achievementScore.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using Newtonsoft.Json;
+using System.IO;
 
 public class achievementScore : MonoBehaviour
 {
@@ -21,5 +23,39 @@ public class achievementScore : MonoBehaviour
     {
         scoreValue = countbids.Count;
         score.text = "Stops Visited:\n" + scoreValue;
+    }
+
+    public static void loadCountBIDS()
+    {
+        Debug.Log("\n\n\n\n ****************** \n\n\n\n LOADING COUNT B IDS \n\n\n\n ****************** \n\n\n\n");
+        if (File.Exists(Application.persistentDataPath + "/countbids.json"))
+        {
+            Debug.Log("\n\n\n\n ****************** \n\n\n\n FOUND countbids.json IN PERSISTENT STORAGE \n\n\n\n ****************** \n\n\n\n");
+            string filePath = Application.persistentDataPath + "/countbids.json";
+            using (StreamReader r = new StreamReader(filePath))
+            {
+                string json = r.ReadToEnd();
+                countbids = JsonConvert.DeserializeObject<List<string>>(json);
+            }
+        }
+        else
+        {
+            Debug.Log("\n\n\n\n ****************** \n\n\n\n DID NOT FIND countbids.JSON IN PERSISTENT STORAGE \n\n\n\n ****************** \n\n\n\n");
+        }
+    }
+
+    public static void addToCountBIDS(string bID)
+    {
+        loadCountBIDS();
+        Debug.Log("\n\n\n\n ****************** \n\n\n\n ADD TO COUNT BIDS CALLED \n\n\n\n ****************** \n\n\n\n");
+        countbids.Add(bID);
+        saveCountBIDS();
+
+    }
+    private static void saveCountBIDS()
+    {
+        Debug.Log("\n\n\n\n ****************** \n\n\n\n SAVING COUNT BIDS NOW \n\n\n\n ****************** \n\n\n\n");
+        string filePath = Application.persistentDataPath + "/countbids.json";
+        File.WriteAllText(filePath, JsonConvert.SerializeObject(countbids));
     }
 }

--- a/TourAR/Assets/Scripts/Achievements/manageAchievements.cs
+++ b/TourAR/Assets/Scripts/Achievements/manageAchievements.cs
@@ -8,13 +8,6 @@ public class manageAchievements : MonoBehaviour
 {
     public static List<Achievement> achievements;
 
-    /*
-        Suggested Workflow:
-          - Create an instance of manageAchievements, which will load data from the JSON.
-          - To add a manage an achievements status:
-            - call toggleAchievementStatus()
-            - IMPORTANT: call saveAchievements() otherwise any changes will not actually update the JSON file.
-    */
     void Start()
     {
         loadAchievements();
@@ -31,10 +24,25 @@ public class manageAchievements : MonoBehaviour
 
     public void loadAchievements()
     {
-        // JUST FILE IO
-        string json = Resources.Load<TextAsset>("JSON/achievements").text;
-        achievements = JsonConvert.DeserializeObject<List<Achievement>>(json);
+        Debug.Log("\n\n\n\n ****************** \n\n\n\n LOADING ACHIEVEMENTS \n\n\n\n ****************** \n\n\n\n");
+        if (File.Exists(Application.persistentDataPath + "/achievements.json"))
+        {
+            Debug.Log("\n\n\n\n ****************** \n\n\n\n FOUND achievements.json IN PERSISTENT STORAGE \n\n\n\n ****************** \n\n\n\n");
+            string filePath = Application.persistentDataPath + "/achievements.json";
+            using (StreamReader r = new StreamReader(filePath))
+            {
+                string json = r.ReadToEnd();
+                achievements = JsonConvert.DeserializeObject<List<Achievement>>(json);
+            }
+        }
+        else
+        {
+            Debug.Log("\n\n\n\n ****************** \n\n\n\n DID NOT FIND achievements.JSON IN PERSISTENT STORAGE \n\n\n\n ****************** \n\n\n\n");
+            string json = Resources.Load<TextAsset>("JSON/achievements").text;
+            achievements = JsonConvert.DeserializeObject<List<Achievement>>(json);
+        }
     }
+
     public bool getAchievementStatus(int index)
     {
         if (index < achievements.Count)
@@ -62,6 +70,7 @@ public class manageAchievements : MonoBehaviour
     }
 
     public void checkIfCompleted() {
+        loadAchievements();
         for (int i = 0; i < achievements.Count; i++) {
             if (achievementScore.countbids.Count >= achievements[i].condition) {
                 achievements[i].isCompleted = true;
@@ -70,21 +79,11 @@ public class manageAchievements : MonoBehaviour
         saveAchievements();
     }
 
-/*    public void addAchievement(string aName, int condition, bool completion, string desc)
-    {
-        Achievement a = new Achievement();
-        a.name = aName;
-        a.condition = condition;
-        a.isCompleted = completion;
-        a.description = desc;
-        achievements.Insert(0, a);
-    }
-*/
-
     public void saveAchievements()
     {
-        //THIS METHOD NEEDS TO BE CALLED TO UPDATE THE JSON FILE
-        File.WriteAllText("Assets/Resources/JSON/achievements.json", JsonConvert.SerializeObject(achievements));
+        Debug.Log("\n\n\n\n ****************** \n\n\n\n SAVING ACHIEVEMENTS NOW \n\n\n\n ****************** \n\n\n\n");
+        string filePath = Application.persistentDataPath + "/achievements.json";
+        File.WriteAllText(filePath, JsonConvert.SerializeObject(achievements));
     }
 
     public void resetAchievements()

--- a/TourAR/Assets/Scripts/History/HistoryList.cs
+++ b/TourAR/Assets/Scripts/History/HistoryList.cs
@@ -13,6 +13,10 @@ public class HistoryList : MonoBehaviour
     void Start()
     {
         score = GetComponent<Text> ();
+        manageTourHistory.loadTourHistory();
+
+        // populate listHistory from manageTourHistory.
+        listHistory = manageTourHistory.getTourHistoryAsString();
     }
 
     // Update is called once per frame
@@ -28,7 +32,10 @@ public class HistoryList : MonoBehaviour
 
     public static void addToTourHistory(string bID)
     {
-        var stopName = loadTourStops.getStopName(bID);
+        var mTS = new loadTourStops();
+        var mTH = new manageTourHistory();
+        string stopName = mTS.getTitleForTourStop(bID);
+        mTH.addStopToHistory(stopName);
         listHistory.Add(stopName);
     }
 }

--- a/TourAR/Assets/Scripts/History/HistoryList.cs
+++ b/TourAR/Assets/Scripts/History/HistoryList.cs
@@ -6,7 +6,7 @@ using UnityEngine.UI;
 public class HistoryList : MonoBehaviour
 {
     public static List<string> listHistory = new List<string>();
-    public int stopsCount = 0;
+    public static int stopsCount = 0;
     Text score;
 
     // Start is called before the first frame update

--- a/TourAR/Assets/Scripts/History/HistoryList.cs
+++ b/TourAR/Assets/Scripts/History/HistoryList.cs
@@ -6,17 +6,13 @@ using UnityEngine.UI;
 public class HistoryList : MonoBehaviour
 {
     public static List<string> listHistory = new List<string>();
-    public static int stopsCount = 0;
+    public int stopsCount = 0;
     Text score;
 
     // Start is called before the first frame update
     void Start()
     {
         score = GetComponent<Text> ();
-        manageTourHistory.loadTourHistory();
-
-        // populate listHistory from manageTourHistory.
-        listHistory = manageTourHistory.getTourHistoryAsString();
     }
 
     // Update is called once per frame
@@ -32,10 +28,16 @@ public class HistoryList : MonoBehaviour
 
     public static void addToTourHistory(string bID)
     {
-        var mTS = new loadTourStops();
+        Debug.Log("\n\n\n\n ****************** \n\n\n\n ADD TO TOUR HISTORY CALLED \n\n\n\n ****************** \n\n\n\n");
         var mTH = new manageTourHistory();
-        string stopName = mTS.getTitleForTourStop(bID);
-        mTH.addStopToHistory(stopName);
-        listHistory.Add(stopName);
+        mTH.addStopToHistory(bID);
+        Debug.Log("\n\n\n\n ****************** \n\n\n\n ADDED TO MANAGE TOUR HISTORY. ABOUT TO UPDATE LIST HISTORY IN HISTORY LIST. \n\n\n\n ****************** \n\n\n\n");
+        listHistory = manageTourHistory.getTourHistoryAsString();
+        Debug.Log("\n\n\n\n ****************** \n\n\n\n JUST UPDATED LIST HISTORY. ABOUT TO PRINT IT \n\n\n\n ****************** \n\n\n\n");
+        for (int i = 0; i < listHistory.Count; i++)
+        {
+            Debug.Log(listHistory[i]);
+        }
+        Debug.Log("\n\n\n\n ****************** \n\n\n\n FINISHED PRINTING LIST HISTORY \n\n\n\n ****************** \n\n\n\n");
     }
 }

--- a/TourAR/Assets/Scripts/History/HistoryList.cs
+++ b/TourAR/Assets/Scripts/History/HistoryList.cs
@@ -25,4 +25,10 @@ public class HistoryList : MonoBehaviour
     public List<string> GetHistory() {
         return listHistory;
     }
+
+    public static void addToTourHistory(string bID)
+    {
+        var stopName = loadTourStops.getStopName(bID);
+        listHistory.Add(stopName);
+    }
 }

--- a/TourAR/Assets/Scripts/History/HistoryList.cs
+++ b/TourAR/Assets/Scripts/History/HistoryList.cs
@@ -31,13 +31,7 @@ public class HistoryList : MonoBehaviour
         Debug.Log("\n\n\n\n ****************** \n\n\n\n ADD TO TOUR HISTORY CALLED \n\n\n\n ****************** \n\n\n\n");
         var mTH = new manageTourHistory();
         mTH.addStopToHistory(bID);
-        Debug.Log("\n\n\n\n ****************** \n\n\n\n ADDED TO MANAGE TOUR HISTORY. ABOUT TO UPDATE LIST HISTORY IN HISTORY LIST. \n\n\n\n ****************** \n\n\n\n");
+        Debug.Log("\n\n\n\n ****************** \n\n\n\n ADDED TO MANAGE TOUR HISTORY. NOW UPDATING LIST HISTORY IN HISTORY LIST. \n\n\n\n ****************** \n\n\n\n");
         listHistory = manageTourHistory.getTourHistoryAsString();
-        Debug.Log("\n\n\n\n ****************** \n\n\n\n JUST UPDATED LIST HISTORY. ABOUT TO PRINT IT \n\n\n\n ****************** \n\n\n\n");
-        for (int i = 0; i < listHistory.Count; i++)
-        {
-            Debug.Log(listHistory[i]);
-        }
-        Debug.Log("\n\n\n\n ****************** \n\n\n\n FINISHED PRINTING LIST HISTORY \n\n\n\n ****************** \n\n\n\n");
     }
 }

--- a/TourAR/Assets/Scripts/History/HistoryListControl.cs
+++ b/TourAR/Assets/Scripts/History/HistoryListControl.cs
@@ -15,6 +15,7 @@ public class HistoryListControl : MonoBehaviour
     {
         yield return null;
         buttons = new List<GameObject>();
+        HistoryList.listHistory = manageTourHistory.getTourHistoryAsString();
 
         if (buttons.Count > 0) {
             foreach (GameObject button in buttons) {
@@ -34,7 +35,7 @@ public class HistoryListControl : MonoBehaviour
     public static void Reset() {
         foreach (var gameObj in GameObject.FindGameObjectsWithTag("HButton")) {
             Destroy(gameObj);
-        }    
+        }
     }
 
     public void ButtonClicked(string myTextString) {

--- a/TourAR/Assets/Scripts/History/HistoryReset.cs
+++ b/TourAR/Assets/Scripts/History/HistoryReset.cs
@@ -6,10 +6,8 @@ public class HistoryReset : MonoBehaviour
 {
     public void resetHistory()
     {
-        for (int i = HistoryList.listHistory.Count - 1; i >=0; i--)
-        {
-            HistoryList.listHistory.RemoveAt(i);
-        }
+        var mTH = new manageTourHistory();
+        mTH.clearTourHistory();
         if (HistoryListControl.buttons.Count > 0) {
             foreach (GameObject button in HistoryListControl.buttons) {
                 Destroy(button.gameObject);

--- a/TourAR/Assets/Scripts/Map/mapPopUp.cs
+++ b/TourAR/Assets/Scripts/Map/mapPopUp.cs
@@ -11,14 +11,14 @@ public class mapPopUp : MonoBehaviour
     public enum yesOrNo {Yes, No};
     [SerializeField] public yesOrNo button;
     public GameObject panel;
-    
+
     public void onClick() {
       switch(button) { // check for type
         case yesOrNo.Yes:
             if (!achievementScore.countbids.Contains(loadTourStops.stopToLoad)) {
                 achievementScore.countbids.Add(loadTourStops.stopToLoad);
             }
-            HistoryList.listHistory.Add(loadTourStops.stopToLoad);
+            HistoryList.addToTourHistory(loadTourStops.stopToLoad);
             SceneManager.LoadScene("ARView");
           break;
         case yesOrNo.No:

--- a/TourAR/Assets/Scripts/Map/mapPopUp.cs
+++ b/TourAR/Assets/Scripts/Map/mapPopUp.cs
@@ -16,7 +16,7 @@ public class mapPopUp : MonoBehaviour
       switch(button) { // check for type
         case yesOrNo.Yes:
             if (!achievementScore.countbids.Contains(loadTourStops.stopToLoad)) {
-                achievementScore.countbids.Add(loadTourStops.stopToLoad);
+                achievementScore.addToCountBIDS(loadTourStops.stopToLoad);
             }
             HistoryList.addToTourHistory(loadTourStops.stopToLoad);
             SceneManager.LoadScene("ARView");

--- a/TourAR/Assets/Scripts/manageTourHistory.cs
+++ b/TourAR/Assets/Scripts/manageTourHistory.cs
@@ -41,6 +41,7 @@ public class manageTourHistory : MonoBehaviour
 
     public static List<string> getTourHistoryAsString()
     {
+        loadTourHistory();
         List<string> histStrList = new List<string>();
         for (int i = 0; i < tourHistory.Count; i++)
         {
@@ -51,8 +52,10 @@ public class manageTourHistory : MonoBehaviour
 
     public static void loadTourHistory()
     {
+        Debug.Log("\n\n\n\n ****************** \n\n\n\n CURRENTLY IN LOAD TOUR HISTORY \n\n\n\n ****************** \n\n\n\n");
         if (File.Exists(Application.persistentDataPath + "/tourHistory.json"))
         {
+            Debug.Log("\n\n\n\n ****************** \n\n\n\n FOUND TOURHISTORY.JSON IN PERSISTENT STORAGE \n\n\n\n ****************** \n\n\n\n");
             string filePath = Application.persistentDataPath + "/tourHistory.json";
             using (StreamReader r = new StreamReader(filePath))
             {
@@ -61,6 +64,7 @@ public class manageTourHistory : MonoBehaviour
             }
         }
         else {
+            Debug.Log("\n\n\n\n ****************** \n\n\n\n DID NOT FIND TOURHISTORY.JSON IN PERSISTENT STORAGE \n\n\n\n ****************** \n\n\n\n");
             string json = Resources.Load<TextAsset>("JSON/tourHistory").text;
             tourHistory = JsonConvert.DeserializeObject<List<tourStopVisited>>(json);
         }
@@ -81,7 +85,7 @@ public class manageTourHistory : MonoBehaviour
         newItem.stopID = tourStopID;
         tourHistory.Insert(0, newItem);
         saveTourHistory();
-        Debug.Log("STOP ADDED TO TOUR HISTORY");
+        Debug.Log("\n\n\n\n ****************** \n\n\n\n STOP ADDED TO MANAGE TOUR HISTORY \n\n\n\n ****************** \n\n\n\n");
     }
 
     public void clearTourHistory()
@@ -91,7 +95,7 @@ public class manageTourHistory : MonoBehaviour
 
     private static void saveTourHistory()
     {
-        Debug.Log("SAVING TOUR HISTORY NOW");
+        Debug.Log("\n\n\n\n ****************** \n\n\n\n SAVING TOUR HISTORY NOW \n\n\n\n ****************** \n\n\n\n");
         string filePath = Application.persistentDataPath + "/tourHistory.json";
         File.WriteAllText(filePath, JsonConvert.SerializeObject(tourHistory));
     }

--- a/TourAR/Assets/Scripts/manageTourHistory.cs
+++ b/TourAR/Assets/Scripts/manageTourHistory.cs
@@ -81,8 +81,19 @@ public class manageTourHistory : MonoBehaviour
         {
             tourHistory.RemoveAt(tourHistoryCap - 1); // we need to remove the last element of the list before adding this one
         }
+        // Try to convert Building ID to stop name
+        var manageTS = new loadTourStops();
+        manageTS.prepForUse();
+        string title = manageTS.getTitleForTourStop(tourStopID); // stop name
         tourStopVisited newItem = new tourStopVisited();
-        newItem.stopID = tourStopID;
+        if ( title == "n/a no match found for this building ID") // If we did not find a name for the ID. Realistically this should only happen with our fake tour stops for testing.
+        {
+            newItem.stopID = tourStopID;
+        }
+        else
+        {
+            newItem.stopID = title;
+        }
         tourHistory.Insert(0, newItem);
         saveTourHistory();
         Debug.Log("\n\n\n\n ****************** \n\n\n\n STOP ADDED TO MANAGE TOUR HISTORY \n\n\n\n ****************** \n\n\n\n");

--- a/TourAR/Assets/Scripts/manageTourHistory.cs
+++ b/TourAR/Assets/Scripts/manageTourHistory.cs
@@ -102,6 +102,7 @@ public class manageTourHistory : MonoBehaviour
     public void clearTourHistory()
     {
         tourHistory.RemoveRange(0, tourHistory.Count);
+        saveTourHistory();
     }
 
     private static void saveTourHistory()

--- a/TourAR/Assets/Scripts/manageTourHistory.cs
+++ b/TourAR/Assets/Scripts/manageTourHistory.cs
@@ -6,14 +6,14 @@ using System.IO;
 
 public class manageTourHistory : MonoBehaviour
 {
-    private List<tourStopVisited> tourHistory;
+    private static List<tourStopVisited> tourHistory;
     private int tourHistoryCap = 10; //Setting as 10 by default
 
     /*
         Suggested Workflow:
           - Create an instance of manageTourHistory, which will load data from the JSON.
           - To add a stop:
-            - call addStopToHistory() 
+            - call addStopToHistory()
             - IMPORTANT: call saveTourHistory() otherwise this will not update the JSON file.
     */
     public manageTourHistory()
@@ -24,8 +24,6 @@ public class manageTourHistory : MonoBehaviour
     public class tourStopVisited
     {
         public string stopID;
-
-        public string completionDate;
     }
 
     public int getTourHistoryCap()
@@ -52,7 +50,7 @@ public class manageTourHistory : MonoBehaviour
         return tourHistory;
     }
 
-    public void addStopToHistory(string tourStopID, string date)
+    public void addStopToHistory(string tourStopID)
     {
         if (tourHistory.Count >= tourHistoryCap)
         {
@@ -61,7 +59,6 @@ public class manageTourHistory : MonoBehaviour
         }
         tourStopVisited newItem = new tourStopVisited();
         newItem.stopID = tourStopID;
-        newItem.completionDate = date;
         tourHistory.Insert(0, newItem);
         saveTourHistory();
     }

--- a/TourAR/Assets/Scripts/manageTourHistory.cs
+++ b/TourAR/Assets/Scripts/manageTourHistory.cs
@@ -7,7 +7,7 @@ using System.IO;
 public class manageTourHistory : MonoBehaviour
 {
     private static List<tourStopVisited> tourHistory;
-    private int tourHistoryCap = 10; //Setting as 10 by default
+    private static int tourHistoryCap = 10; //Setting as 10 by default
 
     /*
         Suggested Workflow:
@@ -39,10 +39,31 @@ public class manageTourHistory : MonoBehaviour
         }
     }
 
-    private void loadTourHistory()
+    public static List<string> getTourHistoryAsString()
     {
-        string json = Resources.Load<TextAsset>("JSON/tourHistory").text;
-        tourHistory = JsonConvert.DeserializeObject<List<tourStopVisited>>(json);
+        List<string> histStrList = new List<string>();
+        for (int i = 0; i < tourHistory.Count; i++)
+        {
+            histStrList.Add(tourHistory[i].stopID);
+        }
+        return histStrList;
+    }
+
+    public static void loadTourHistory()
+    {
+        if (File.Exists(Application.persistentDataPath + "/tourHistory.json"))
+        {
+            string filePath = Application.persistentDataPath + "/tourHistory.json";
+            using (StreamReader r = new StreamReader(filePath))
+            {
+                string json = r.ReadToEnd();
+                tourHistory = JsonConvert.DeserializeObject<List<tourStopVisited>>(json);
+            }
+        }
+        else {
+            string json = Resources.Load<TextAsset>("JSON/tourHistory").text;
+            tourHistory = JsonConvert.DeserializeObject<List<tourStopVisited>>(json);
+        }
     }
 
     public List<tourStopVisited> getTourHistory()
@@ -54,13 +75,13 @@ public class manageTourHistory : MonoBehaviour
     {
         if (tourHistory.Count >= tourHistoryCap)
         {
-            // we need to remove the last element of the list before adding this one
-            tourHistory.RemoveAt(tourHistoryCap - 1);
+            tourHistory.RemoveAt(tourHistoryCap - 1); // we need to remove the last element of the list before adding this one
         }
         tourStopVisited newItem = new tourStopVisited();
         newItem.stopID = tourStopID;
         tourHistory.Insert(0, newItem);
         saveTourHistory();
+        Debug.Log("STOP ADDED TO TOUR HISTORY");
     }
 
     public void clearTourHistory()
@@ -68,8 +89,10 @@ public class manageTourHistory : MonoBehaviour
         tourHistory.RemoveRange(0, tourHistory.Count);
     }
 
-    public void saveTourHistory()
+    private static void saveTourHistory()
     {
-        File.WriteAllText("Assets/Resources/JSON/tourHistory.json", JsonConvert.SerializeObject(tourHistory));
+        Debug.Log("SAVING TOUR HISTORY NOW");
+        string filePath = Application.persistentDataPath + "/tourHistory.json";
+        File.WriteAllText(filePath, JsonConvert.SerializeObject(tourHistory));
     }
 }


### PR DESCRIPTION
Closes #111

- [x] Integrate ManageTourHistory with the Tour History scene.

- [x] Identify why persistent storage is not working correctly

- [x] Create a fix for the persistent storage bug in Tour History

- [x] Create a fix for the persistent storage bug in Achievements

- [x] Change Tour History script so that it stores stop name instead of building ID